### PR TITLE
fixed(App.jsx): using a map for modifying isCompleted in a todo item

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,9 +28,13 @@ function App() {
 
   const handleClick = (index) => {
     setTodos((prevTodos) => {
-      const updatedTodos = [...prevTodos];
-      updatedTodos[index].isCompleted = !updatedTodos[index].isCompleted;
-      return updatedTodos;
+      return prevTodos.map((todo, i) => {
+        if (i === index) {
+          return { ...todo, isCompleted: !todo.isCompleted };
+        } else {
+          return todo;
+        }
+      });
     });
   };
 


### PR DESCRIPTION
```js
const updatedTodos = [...prevTodos];
updatedTodos[index].isCompleted = !updatedTodos[index].isCompleted;
```

This creates a shallow copy of a todo but still modifies the actual todo which can cause unexpected behaviour... but a map will create another todo item and previous todo will be replaced completely rather getting modified directly